### PR TITLE
Implement RFC 0050: Rename Buildpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # `docker.io/paketobuildpacks/dynatrace`
-The Paketo Dynatrace Buildpack is a Cloud Native Buildpack that contributes the Dynatrace OneAgent and configures it to connect to the service.
+The Paketo Buildpack for Dynatrace is a Cloud Native Buildpack that contributes the Dynatrace OneAgent and configures it to connect to the service.
 
 ## Behavior
 This buildpack will participate if all the following conditions are met

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -19,7 +19,7 @@ api = "0.7"
   homepage = "https://github.com/paketo-buildpacks/dynatrace"
   id = "paketo-buildpacks/dynatrace"
   keywords = ["dynatrace", "agent", "one-agent", "apm", "java", "node.js", "go", "apache-httpd", "nginx", "php", "dotnet"]
-  name = "Paketo Dynatrace Buildpack"
+  name = "Paketo Buildpack for Dynatrace"
   sbom-formats = ["application/vnd.syft+json", "application/vnd.cyclonedx+json"]
   version = "{{.version}}"
 


### PR DESCRIPTION
Renames 'Paketo Dynatrace Buildpack' to 'Paketo Buildpack for Dynatrace'.

Implements RFC 0050, https://github.com/paketo-buildpacks/rfcs/issues/233, for this buildpack.

Signed-off-by: Daniel Mikusa <dmikusa@vmware.com>
