### PR TITLE
Adds node_modules to node detection criteria

### DIFF
--- a/dt/detect.go
+++ b/dt/detect.go
@@ -98,6 +98,7 @@ func (Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) 
 				Requires: []libcnb.BuildPlanRequire{
 					{Name: "dynatrace-nodejs"},
 					{Name: "node"},
+					{Name: "node_modules"},
 				},
 			},
 			{

--- a/dt/detect_test.go
+++ b/dt/detect_test.go
@@ -66,15 +66,15 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					},
 				},
 				{
-                                	Provides: []libcnb.BuildPlanProvide{
-                                        	{Name: "dynatrace-dotnet"},
-                                },
-                                	Requires: []libcnb.BuildPlanRequire{
-                                        	{Name: "dynatrace-dotnet"},
-                                        	{Name: "dotnet-core-aspnet-runtime"},
-                                        	{Name: "node"},
-                                	},
-                                },
+					Provides: []libcnb.BuildPlanProvide{
+						{Name: "dynatrace-dotnet"},
+					},
+					Requires: []libcnb.BuildPlanRequire{
+						{Name: "dynatrace-dotnet"},
+						{Name: "dotnet-core-aspnet-runtime"},
+						{Name: "node"},
+					},
+				},
 				{
 					Provides: []libcnb.BuildPlanProvide{
 						{Name: "dynatrace-go"},
@@ -109,6 +109,7 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 					Requires: []libcnb.BuildPlanRequire{
 						{Name: "dynatrace-nodejs"},
 						{Name: "node"},
+						{Name: "node_modules"},
 					},
 				},
 				{


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
Changes node detection criteria to include `node_modules` - this ensures node is not provided by the Java buildpack inadvertently.

## Use Cases
Fixes paketo-buildpacks/new-relic#73

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
