### PR TITLE
Also lookup binding withName

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,14 @@
 The Paketo Buildpack for Dynatrace is a Cloud Native Buildpack that contributes the Dynatrace OneAgent and configures it to connect to the service.
 
 ## Behavior
-This buildpack will participate if all the following conditions are met
+This buildpack will participate if one the following conditions are met
 
+* A binding exists with `name` of `Dynatrace`
 * A binding exists with `type` of `Dynatrace`
 
 **Note**: The binding must include the following required Secret values to successfully contribute Dynatrace
+
+**Note**: If both bindings (`name` **and** `type`) exist, the binding with `name` will have precedence.
 
 | Key | Value Description
 | -------------------- | -----------

--- a/dt/build.go
+++ b/dt/build.go
@@ -43,9 +43,15 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 	dc.Logger = b.Logger
 
-	s, _, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("Dynatrace"))
+	s, bindingFound, err := bindings.ResolveOne(context.Platform.Bindings, bindings.WithName("Dynatrace"))
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve binding Dynatrace\n%w", err)
+	}
+	if !bindingFound {
+		s, _, err = bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("Dynatrace"))
+		if err != nil {
+			return libcnb.BuildResult{}, fmt.Errorf("unable to resolve binding Dynatrace\n%w", err)
+		}
 	}
 
 	v, err := b.AgentVersion(s, context.Buildpack.Info)

--- a/dt/detect.go
+++ b/dt/detect.go
@@ -20,19 +20,21 @@ import (
 	"fmt"
 
 	"github.com/buildpacks/libcnb"
-	"github.com/paketo-buildpacks/libpak/bindings"
 	"github.com/paketo-buildpacks/libpak/bard"
+	"github.com/paketo-buildpacks/libpak/bindings"
 )
 
-type Detect struct{
+type Detect struct {
 	Logger bard.Logger
 }
 
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
-	if _, ok, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("Dynatrace")); err != nil {
+	if _, nameFound, err := bindings.ResolveOne(context.Platform.Bindings, bindings.WithName("Dynatrace")); err != nil {
 		return libcnb.DetectResult{}, fmt.Errorf("unable to resolve binding Dynatrace\n%w", err)
-	} else if !ok {
-		d.Logger.Info("SKIPPED: No binding of type 'Dynatrace' found")
+	} else if _, typeFound, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("Dynatrace")); err != nil {
+		return libcnb.DetectResult{}, fmt.Errorf("unable to resolve binding Dynatrace\n%w", err)
+	} else if !nameFound && !typeFound {
+		d.Logger.Info("SKIPPED: No binding for 'Dynatrace' found (type or name)")
 		return libcnb.DetectResult{Pass: false}, nil
 	}
 

--- a/dt/detect_test.go
+++ b/dt/detect_test.go
@@ -26,6 +26,87 @@ import (
 	"github.com/paketo-buildpacks/dynatrace/v4/dt"
 )
 
+var expectedResult = libcnb.DetectResult{
+	Pass: true,
+	Plans: []libcnb.BuildPlan{
+		{
+			Provides: []libcnb.BuildPlanProvide{
+				{Name: "dynatrace-apache"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+				{Name: "dynatrace-apache"},
+				{Name: "httpd"},
+			},
+		},
+		{
+			Provides: []libcnb.BuildPlanProvide{
+				{Name: "dynatrace-dotnet"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+				{Name: "dynatrace-dotnet"},
+				{Name: "dotnet-runtime"},
+				{Name: "node"},
+			},
+		},
+		{
+			Provides: []libcnb.BuildPlanProvide{
+				{Name: "dynatrace-dotnet"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+				{Name: "dynatrace-dotnet"},
+				{Name: "dotnet-core-aspnet-runtime"},
+				{Name: "node"},
+			},
+		},
+		{
+			Provides: []libcnb.BuildPlanProvide{
+				{Name: "dynatrace-go"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+				{Name: "dynatrace-go"},
+				{Name: "go"},
+			},
+		},
+		{
+			Provides: []libcnb.BuildPlanProvide{
+				{Name: "dynatrace-java"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+				{Name: "dynatrace-java"},
+				{Name: "jvm-application"},
+			},
+		},
+		{
+			Provides: []libcnb.BuildPlanProvide{
+				{Name: "dynatrace-nginx"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+				{Name: "dynatrace-nginx"},
+				{Name: "nginx"},
+			},
+		},
+		{
+			Provides: []libcnb.BuildPlanProvide{
+				{Name: "dynatrace-nodejs"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+				{Name: "dynatrace-nodejs"},
+				{Name: "node"},
+				{Name: "node_modules"},
+			},
+		},
+		{
+			Provides: []libcnb.BuildPlanProvide{
+				{Name: "dynatrace-php"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+				{Name: "dynatrace-php"},
+				{Name: "php"},
+			},
+		},
+	},
+}
+
 func testDetect(t *testing.T, context spec.G, it spec.S) {
 	var (
 		Expect = NewWithT(t).Expect
@@ -34,94 +115,59 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		detect dt.Detect
 	)
 
-	it("fails without service", func() {
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{}))
+	it("fails detection without service", func() {
+		actualResult, err := detect.Detect(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(actualResult.Pass).To(BeFalse())
+		Expect(actualResult).To(Equal(libcnb.DetectResult{}))
 	})
 
-	it("passes with service", func() {
+	it("passes with service of type dynatrace", func() {
 		ctx.Platform.Bindings = libcnb.Bindings{
 			{Name: "test-service", Type: "Dynatrace"},
 		}
 
-		Expect(detect.Detect(ctx)).To(Equal(libcnb.DetectResult{
-			Pass: true,
-			Plans: []libcnb.BuildPlan{
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "dynatrace-apache"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "dynatrace-apache"},
-						{Name: "httpd"},
-					},
-				},
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "dynatrace-dotnet"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "dynatrace-dotnet"},
-						{Name: "dotnet-runtime"},
-						{Name: "node"},
-					},
-				},
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "dynatrace-dotnet"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "dynatrace-dotnet"},
-						{Name: "dotnet-core-aspnet-runtime"},
-						{Name: "node"},
-					},
-				},
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "dynatrace-go"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "dynatrace-go"},
-						{Name: "go"},
-					},
-				},
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "dynatrace-java"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "dynatrace-java"},
-						{Name: "jvm-application"},
-					},
-				},
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "dynatrace-nginx"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "dynatrace-nginx"},
-						{Name: "nginx"},
-					},
-				},
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "dynatrace-nodejs"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "dynatrace-nodejs"},
-						{Name: "node"},
-						{Name: "node_modules"},
-					},
-				},
-				{
-					Provides: []libcnb.BuildPlanProvide{
-						{Name: "dynatrace-php"},
-					},
-					Requires: []libcnb.BuildPlanRequire{
-						{Name: "dynatrace-php"},
-						{Name: "php"},
-					},
-				},
-			},
-		}))
+		actualResult, err := detect.Detect(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(actualResult.Pass).To(BeTrue())
+		Expect(actualResult).To(Equal(expectedResult))
 	})
+
+	it("passes with service with name dynatrace", func() {
+		ctx.Platform.Bindings = libcnb.Bindings{
+			{Name: "Dynatrace", Type: "user-provided"},
+		}
+
+		actualResult, err := detect.Detect(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(actualResult.Pass).To(BeTrue())
+		Expect(actualResult).To(Equal(expectedResult))
+	})
+
+	it("passes with services with name and of type dynatrace", func() {
+		ctx.Platform.Bindings = libcnb.Bindings{
+			{Name: "Dynatrace", Type: "user-provided"},
+			{Name: "provided", Type: "Dynatrace"},
+		}
+
+		actualResult, err := detect.Detect(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(actualResult.Pass).To(BeTrue())
+		Expect(actualResult).To(Equal(expectedResult))
+	})
+
+	it("errors with multiple services with name dynatrace", func() {
+		ctx.Platform.Bindings = libcnb.Bindings{
+			{Name: "Dynatrace", Type: "user-provided"},
+			{Name: "Dynatrace", Type: "user-provided"},
+		}
+
+		_, err := detect.Detect(ctx)
+		Expect(err).To(MatchError(ContainSubstring("unable to resolve")))
+	})
+
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
The dynatrace binding is not only discovered `byType`, but also `withName`. If there is a binding with the name 'Dynatrace', it will be used with precedence.

## Use Cases
<!-- An explanation of the use cases your change enables -->
To support the `cf` scenario where bindings are read from `VCAP_SERVICES`. With `user-provided services`, the `type` cannot be influenced, but the name can be set to 'Dynatrace'.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
