### PR TITLE
Use binding with matching name in helper if available

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,14 +2,15 @@
 The Paketo Buildpack for Dynatrace is a Cloud Native Buildpack that contributes the Dynatrace OneAgent and configures it to connect to the service.
 
 ## Behavior
-This buildpack will participate if one the following conditions are met
+This buildpack will participate if either of the following conditions is met
 
-* A binding exists with `name` of `Dynatrace`
+* A binding exists with `name` containing `Dynatrace`
 * A binding exists with `type` of `Dynatrace`
+
+**Note**:  While a single binding may match both conditions, you may *not* have multiple bindings that match the conditions above. Multiple Dynatrace service bindings are not supported for a single application.
 
 **Note**: The binding must include the following required Secret values to successfully contribute Dynatrace
 
-**Note**: If both bindings (`name` **and** `type`) exist, the binding with `name` will have precedence.
 
 | Key | Value Description
 | -------------------- | -----------

--- a/dt/binding_predicate.go
+++ b/dt/binding_predicate.go
@@ -1,0 +1,20 @@
+package dt
+
+import (
+	"strings"
+
+	"github.com/buildpacks/libcnb"
+	"github.com/paketo-buildpacks/libpak/bindings"
+)
+
+func IsDynatraceBinding(bind libcnb.Binding) bool {
+	if bindings.OfType("Dynatrace")(bind) {
+		return true
+	}
+
+	if strings.Contains(strings.ToLower(bind.Name), "dynatrace") {
+		return true
+	}
+
+	return false
+}

--- a/dt/binding_predicate_test.go
+++ b/dt/binding_predicate_test.go
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2018-2022 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package dt_test
+
+import (
+	"testing"
+
+	"github.com/buildpacks/libcnb"
+	. "github.com/onsi/gomega"
+	"github.com/paketo-buildpacks/dynatrace/v4/dt"
+	"github.com/sclevine/spec"
+)
+
+func testIsDynatraceBinding(t *testing.T, context spec.G, it spec.S) {
+	it("returns false for initial binding", func() {
+		result := dt.IsDynatraceBinding(libcnb.Binding{})
+		Expect(result).To(BeFalse())
+	})
+
+	it("returns false for non dynatrace binding", func() {
+		result := dt.IsDynatraceBinding(libcnb.Binding{Name: "foo", Type: "bar"})
+		Expect(result).To(BeFalse())
+	})
+
+	it("returns true for the type Dynatrace", func() {
+		result := dt.IsDynatraceBinding(libcnb.Binding{Name: "foo", Type: "Dynatrace"})
+		Expect(result).To(BeTrue())
+	})
+
+	it("returns true for the type dynatrace", func() {
+		result := dt.IsDynatraceBinding(libcnb.Binding{Name: "foo", Type: "dynatrace"})
+		Expect(result).To(BeTrue())
+	})
+
+	it("returns true for the name Dynatrace", func() {
+		result := dt.IsDynatraceBinding(libcnb.Binding{Name: "Dynatrace", Type: "user-provided"})
+		Expect(result).To(BeTrue())
+	})
+
+	it("returns true if the name contains dynatrace", func() {
+		result := dt.IsDynatraceBinding(libcnb.Binding{Name: "my-dynatrace-binding", Type: "user-provided"})
+		Expect(result).To(BeFalse())
+	})
+
+}

--- a/dt/build.go
+++ b/dt/build.go
@@ -43,15 +43,9 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 	}
 	dc.Logger = b.Logger
 
-	s, bindingFound, err := bindings.ResolveOne(context.Platform.Bindings, bindings.WithName("Dynatrace"))
+	s, _, err := bindings.ResolveOne(context.Platform.Bindings, IsDynatraceBinding)
 	if err != nil {
 		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve binding Dynatrace\n%w", err)
-	}
-	if !bindingFound {
-		s, _, err = bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("Dynatrace"))
-		if err != nil {
-			return libcnb.BuildResult{}, fmt.Errorf("unable to resolve binding Dynatrace\n%w", err)
-		}
 	}
 
 	v, err := b.AgentVersion(s, context.Buildpack.Info)

--- a/dt/build_test.go
+++ b/dt/build_test.go
@@ -125,16 +125,17 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		verifyBOM(result.BOM)
 	})
 
-	it("prefers binding with matching name over type", func() {
-		ctx.Platform.Bindings = append(ctx.Platform.Bindings, libcnb.Binding{
-			Name: "Dynatrace",
-			Type: "user-provided",
-			Secret: map[string]string{
-				"api-token": "custom-api-token",
-				"api-url":   server.URL(),
+	it("also takes named binding into account", func() {
+		ctx.Platform.Bindings = libcnb.Bindings{
+			{
+				Name: "DynatraceBinding",
+				Type: "user-provided",
+				Secret: map[string]string{
+					"api-token": "custom-api-token",
+					"api-url":   server.URL(),
+				},
 			},
-		},
-		)
+		}
 
 		server.SetHandler(0, ghttp.CombineHandlers(
 			ghttp.VerifyRequest("GET", "/v1/deployment/installer/agent/unix/paas/latest/metainfo"),

--- a/dt/detect.go
+++ b/dt/detect.go
@@ -29,11 +29,10 @@ type Detect struct {
 }
 
 func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error) {
-	if _, nameFound, err := bindings.ResolveOne(context.Platform.Bindings, bindings.WithName("Dynatrace")); err != nil {
+	_, ok, err := bindings.ResolveOne(context.Platform.Bindings, IsDynatraceBinding)
+	if err != nil {
 		return libcnb.DetectResult{}, fmt.Errorf("unable to resolve binding Dynatrace\n%w", err)
-	} else if _, typeFound, err := bindings.ResolveOne(context.Platform.Bindings, bindings.OfType("Dynatrace")); err != nil {
-		return libcnb.DetectResult{}, fmt.Errorf("unable to resolve binding Dynatrace\n%w", err)
-	} else if !nameFound && !typeFound {
+	} else if !ok {
 		d.Logger.Info("SKIPPED: No binding for 'Dynatrace' found (type or name)")
 		return libcnb.DetectResult{Pass: false}, nil
 	}

--- a/dt/detect_test.go
+++ b/dt/detect_test.go
@@ -147,27 +147,13 @@ func testDetect(t *testing.T, context spec.G, it spec.S) {
 		Expect(actualResult).To(Equal(expectedResult))
 	})
 
-	it("passes with services with name and of type dynatrace", func() {
+	it("fails with multiple matching services provided", func() {
 		ctx.Platform.Bindings = libcnb.Bindings{
 			{Name: "Dynatrace", Type: "user-provided"},
 			{Name: "provided", Type: "Dynatrace"},
 		}
 
-		actualResult, err := detect.Detect(ctx)
-		Expect(err).NotTo(HaveOccurred())
-
-		Expect(actualResult.Pass).To(BeTrue())
-		Expect(actualResult).To(Equal(expectedResult))
-	})
-
-	it("errors with multiple services with name dynatrace", func() {
-		ctx.Platform.Bindings = libcnb.Bindings{
-			{Name: "Dynatrace", Type: "user-provided"},
-			{Name: "Dynatrace", Type: "user-provided"},
-		}
-
 		_, err := detect.Detect(ctx)
 		Expect(err).To(MatchError(ContainSubstring("unable to resolve")))
 	})
-
 }

--- a/helper/properties.go
+++ b/helper/properties.go
@@ -36,7 +36,7 @@ type Properties struct {
 }
 
 func (p Properties) Execute() (map[string]string, error) {
-	b, ok, err := bindings.ResolveOne(p.Bindings, bindings.OfType("Dynatrace"))
+	b, ok, err := bindings.ResolveOne(p.Bindings, dt.IsDynatraceBinding)
 	if err != nil {
 		return nil, fmt.Errorf("unable to resolve binding Dynatrace\n%w", err)
 	} else if !ok {


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
leftover from https://github.com/paketo-buildpacks/dynatrace/pull/63

The dynatrace binding is not only discovered byType, but also if the name is matching.

## Use Cases
<!-- An explanation of the use cases your change enables -->
To support the `cf` scenario where bindings are read from VCAP_SERVICES. With user-provided services, the type cannot be influenced, but the name can be set to 'Dynatrace'.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
