### PR TITLE
Add ARM64 Support

### DIFF
--- a/.github/pipeline-descriptor.yml
+++ b/.github/pipeline-descriptor.yml
@@ -2,6 +2,9 @@ github:
   username: ${{ secrets.JAVA_GITHUB_USERNAME }}
   token:    ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
 
+helpers:
+  "bin/helper": "$GOMOD/cmd/helper"
+
 codeowners:
 - path:  "*"
   owner: "@paketo-buildpacks/app-monitoring-maintainers"

--- a/.github/workflows/pb-create-package.yml
+++ b/.github/workflows/pb-create-package.yml
@@ -37,9 +37,20 @@ jobs:
               with:
                 crane-version: 0.19.0
                 yj-version: 5.1.0
-            - uses: buildpacks/github-actions/setup-pack@v5.5.3
-              with:
-                pack-version: 0.33.2
+            - name: Install pack
+              run: |
+                #!/usr/bin/env bash
+                # this is coming from a copy of https://github.com/buildpacks/pack/actions/runs/8118576298 stored on box
+                # TODO to revisit when the official one is out
+                set -euo pipefail
+
+                echo "Installing pack experimental"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl -L "https://ent.box.com/shared/static/j4d1bfe9uk1sb0i7zjvci0md9xmy41u4" -o ${HOME}/bin/pack
+                chmod +x "${HOME}"/bin/pack
             - name: Enable pack Experimental
               if: ${{ false }}
               run: |
@@ -106,21 +117,23 @@ jobs:
 
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
                   create-package \
-                    --source ${SOURCE_PATH:-.} \
+                    --source "${SOURCE_PATH:-.}" \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \
                     --include-dependencies \
                     --version "${VERSION}"
                 else
                   create-package \
-                    --source ${SOURCE_PATH:-.} \
+                    --source "${SOURCE_PATH:-.}" \
                     --destination "${HOME}"/buildpack \
                     --version "${VERSION}"
                 fi
 
-                PACKAGE_FILE=${SOURCE_PATH:-.}/package.toml
-                [[ -e ${PACKAGE_FILE} ]] && cp ${PACKAGE_FILE} "${HOME}"/package.toml
-                printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}"/buildpack "${OS}" >> "${HOME}"/package.toml
+                PACKAGE_FILE="${SOURCE_PATH:-.}/package.toml"
+                if [ -f "${PACKAGE_FILE}" ]; then
+                  cp "${PACKAGE_FILE}" "${HOME}/buildpack/package.toml"
+                  printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}/buildpack" "${OS}" >> "${HOME}/buildpack/package.toml"
+                fi
               env:
                 INCLUDE_DEPENDENCIES: "false"
                 OS: linux
@@ -133,15 +146,23 @@ jobs:
 
                 set -euo pipefail
 
+                COMPILED_BUILDPACK="${HOME}/buildpack"
+
+                # create-package puts the buildpack here, we need to run from that directory
+                #   for component buildpacks so that pack doesn't need a package.toml
+                cd "${COMPILED_BUILDPACK}"
+                CONFIG=""
+                if [ -f "${COMPILED_BUILDPACK}/package.toml" ]; then
+                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml"
+                fi
 
                 PACKAGE_LIST=($PACKAGES)
                 # Extract first repo (Docker Hub) as the main to package & register
                 PACKAGE=${PACKAGE_LIST[0]}
 
                 if [[ "${PUBLISH:-x}" == "true" ]]; then
-                  pack buildpack package \
-                    "${PACKAGE}:${VERSION}" \
-                    --config "${HOME}"/package.toml \
+                  pack -v buildpack package \
+                    "${PACKAGE}:${VERSION}" ${CONFIG} \
                     --publish
 
                   if [[ -n ${VERSION_MINOR:-} && -n ${VERSION_MAJOR:-} ]]; then
@@ -165,10 +186,9 @@ jobs:
                     done
 
                 else
-                  pack buildpack package \
-                    "${PACKAGE}:${VERSION}" \
-                    --config "${HOME}"/package.toml \
-                    --format "${FORMAT}"
+                  pack -v buildpack package \
+                    "${PACKAGE}:${VERSION}" ${CONFIG} \
+                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
                 fi
               env:
                 PACKAGES: docker.io/paketobuildpacks/dynatrace gcr.io/paketo-buildpacks/dynatrace
@@ -199,7 +219,7 @@ jobs:
                 DIGEST: ${{ steps.package.outputs.digest }}
                 GITHUB_TOKEN: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
             - if: ${{ true }}
-              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:4.0.1
+              uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:5.5.3
               with:
                 address: docker.io/paketobuildpacks/dynatrace@${{ steps.package.outputs.digest }}
                 id: paketo-buildpacks/dynatrace

--- a/.github/workflows/pb-tests.yml
+++ b/.github/workflows/pb-tests.yml
@@ -25,9 +25,20 @@ jobs:
                 set -euo pipefail
 
                 go install -ldflags="-s -w" github.com/paketo-buildpacks/libpak/cmd/create-package@latest
-            - uses: buildpacks/github-actions/setup-pack@v5.5.3
-              with:
-                pack-version: 0.33.2
+            - name: Install pack
+              run: |
+                #!/usr/bin/env bash
+                # this is coming from a copy of https://github.com/buildpacks/pack/actions/runs/8118576298 stored on box
+                # TODO to revisit when the official one is out
+                set -euo pipefail
+
+                echo "Installing pack experimental"
+
+                mkdir -p "${HOME}"/bin
+                echo "${HOME}/bin" >> "${GITHUB_PATH}"
+
+                curl -L "https://ent.box.com/shared/static/j4d1bfe9uk1sb0i7zjvci0md9xmy41u4" -o ${HOME}/bin/pack
+                chmod +x "${HOME}"/bin/pack
             - name: Enable pack Experimental
               if: ${{ false }}
               run: |
@@ -93,21 +104,23 @@ jobs:
 
                 if [[ "${INCLUDE_DEPENDENCIES}" == "true" ]]; then
                   create-package \
-                    --source ${SOURCE_PATH:-.} \
+                    --source "${SOURCE_PATH:-.}" \
                     --cache-location "${HOME}"/carton-cache \
                     --destination "${HOME}"/buildpack \
                     --include-dependencies \
                     --version "${VERSION}"
                 else
                   create-package \
-                    --source ${SOURCE_PATH:-.} \
+                    --source "${SOURCE_PATH:-.}" \
                     --destination "${HOME}"/buildpack \
                     --version "${VERSION}"
                 fi
 
-                PACKAGE_FILE=${SOURCE_PATH:-.}/package.toml
-                [[ -e ${PACKAGE_FILE} ]] && cp ${PACKAGE_FILE} "${HOME}"/package.toml
-                printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}"/buildpack "${OS}" >> "${HOME}"/package.toml
+                PACKAGE_FILE="${SOURCE_PATH:-.}/package.toml"
+                if [ -f "${PACKAGE_FILE}" ]; then
+                  cp "${PACKAGE_FILE}" "${HOME}/buildpack/package.toml"
+                  printf '[buildpack]\nuri = "%s"\n\n[platform]\nos = "%s"\n' "${HOME}/buildpack" "${OS}" >> "${HOME}/buildpack/package.toml"
+                fi
               env:
                 INCLUDE_DEPENDENCIES: "true"
                 OS: linux
@@ -118,15 +131,23 @@ jobs:
 
                 set -euo pipefail
 
+                COMPILED_BUILDPACK="${HOME}/buildpack"
+
+                # create-package puts the buildpack here, we need to run from that directory
+                #   for component buildpacks so that pack doesn't need a package.toml
+                cd "${COMPILED_BUILDPACK}"
+                CONFIG=""
+                if [ -f "${COMPILED_BUILDPACK}/package.toml" ]; then
+                  CONFIG="--config ${COMPILED_BUILDPACK}/package.toml"
+                fi
 
                 PACKAGE_LIST=($PACKAGES)
                 # Extract first repo (Docker Hub) as the main to package & register
                 PACKAGE=${PACKAGE_LIST[0]}
 
                 if [[ "${PUBLISH:-x}" == "true" ]]; then
-                  pack buildpack package \
-                    "${PACKAGE}:${VERSION}" \
-                    --config "${HOME}"/package.toml \
+                  pack -v buildpack package \
+                    "${PACKAGE}:${VERSION}" ${CONFIG} \
                     --publish
 
                   if [[ -n ${VERSION_MINOR:-} && -n ${VERSION_MAJOR:-} ]]; then
@@ -150,14 +171,14 @@ jobs:
                     done
 
                 else
-                  pack buildpack package \
-                    "${PACKAGE}:${VERSION}" \
-                    --config "${HOME}"/package.toml \
-                    --format "${FORMAT}"
+                  pack -v buildpack package \
+                    "${PACKAGE}:${VERSION}" ${CONFIG} \
+                    --format "${FORMAT}" $([ -n "$TTL_SH_PUBLISH" ] && [ "$TTL_SH_PUBLISH" = "true" ] && echo "--publish")
                 fi
               env:
                 FORMAT: image
                 PACKAGES: test
+                TTL_SH_PUBLISH: "false"
                 VERSION: ${{ steps.version.outputs.version }}
     unit:
         name: Unit Test

--- a/.github/workflows/pb-update-pipeline.yml
+++ b/.github/workflows/pb-update-pipeline.yml
@@ -55,6 +55,12 @@ jobs:
                 )
 
                 git add .github/
+                git add .gitignore
+
+                if [ -f scripts/build.sh ]; then
+                  git add scripts/build.sh
+                fi
+
                 git checkout -- .
 
                 echo "old-version=${OLD_VERSION}" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 the original author or authors.
+# Copyright 2018-2020 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,7 +13,8 @@
 # limitations under the License.
 
 bin/
+linux/
 dependencies/
 package/
 scratch/
-.idea/
+

--- a/buildpack.toml
+++ b/buildpack.toml
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 the original author or authors.
+# Copyright 2018-2024 the original author or authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -28,14 +28,16 @@ api = "0.7"
     uri = "https://github.com/paketo-buildpacks/dynatrace/blob/main/LICENSE"
 
 [metadata]
-  include-files = ["LICENSE", "NOTICE", "README.md", "bin/build", "bin/detect", "bin/helper", "bin/main", "buildpack.toml"]
+  include-files = ["LICENSE", "NOTICE", "README.md", "linux/amd64/bin/build", "linux/amd64/bin/detect", "linux/amd64/bin/main", "linux/amd64/bin/helper", "linux/arm64/bin/build", "linux/arm64/bin/detect", "linux/arm64/bin/main", "linux/arm64/bin/helper", "buildpack.toml"]
   pre-package = "scripts/build.sh"
 
 [[stacks]]
-  id = "io.buildpacks.stacks.bionic"
-
-[[stacks]]
-  id = "io.paketo.stacks.tiny"
-
-[[stacks]]
   id = "*"
+
+[[targets]]
+  arch = "amd64"
+  os = "linux"
+
+[[targets]]
+  arch = "arm64"
+  os = "linux"

--- a/dt/build_test.go
+++ b/dt/build_test.go
@@ -1,5 +1,5 @@
 /*
- * Copyright 2018-2023 the original author or authors.
+ * Copyright 2018-2024 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -37,7 +37,7 @@ func getExpectedDependency(serverUrl string) libpak.BuildpackDependency {
 		ID:      "dynatrace-oneagent",
 		Name:    "Dynatrace OneAgent",
 		Version: "test-version",
-		URI:     fmt.Sprintf("%s/v1/deployment/installer/agent/unix/paas/latest?bitness=64&skipMetadata=true&include=java&include=php", serverUrl),
+		URI:     fmt.Sprintf("%s/v1/deployment/installer/agent/unix/paas/latest?bitness=64&skipMetadata=true&arch=x86&include=java&include=php", serverUrl),
 		Stacks:  []string{stackId},
 		PURL:    "pkg:generic/dynatrace-one-agent@test-version?arch=amd64",
 		CPEs:    []string{"cpe:2.3:a:dynatrace:one-agent:test-version:*:*:*:*:*:*:*"},
@@ -75,6 +75,8 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		RegisterTestingT(t)
 		server = ghttp.NewServer()
 
+		t.Setenv("BP_ARCH", "amd64")
+
 		ctx.Buildpack.Info.ID = "test-id"
 		ctx.Buildpack.Info.Version = "test-version"
 		ctx.StackID = stackId
@@ -107,17 +109,7 @@ func testBuild(t *testing.T, context spec.G, it spec.S) {
 		server.Close()
 	})
 
-	it("contributes agent for API 0.7+", func() {
-		result, err := dt.Build{}.Build(ctx)
-		Expect(err).NotTo(HaveOccurred())
-
-		verifyLayers(result.Layers, server.URL())
-		verifyBOM(result.BOM)
-	})
-
-	it("contributes agent for API <= 0.6", func() {
-		ctx.Buildpack.API = "0.6"
-
+	it("contributes agent", func() {
 		result, err := dt.Build{}.Build(ctx)
 		Expect(err).NotTo(HaveOccurred())
 

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,17 +1,23 @@
 #!/usr/bin/env bash
-
 set -euo pipefail
 
-GOOS="linux" go build -ldflags='-s -w' -o bin/helper github.com/paketo-buildpacks/dynatrace/v4/cmd/helper
-GOOS="linux" go build -ldflags='-s -w' -o bin/main github.com/paketo-buildpacks/dynatrace/v4/cmd/main
+GOMOD=$(head -1 go.mod | awk '{print $2}')
+GOOS="linux" GOARCH="amd64" go build -ldflags='-s -w' -o "linux/amd64/bin/helper" "$GOMOD/cmd/helper"
+GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o "linux/arm64/bin/helper" "$GOMOD/cmd/helper"
+GOOS="linux" GOARCH="amd64" go build -ldflags='-s -w' -o linux/amd64/bin/main "$GOMOD/cmd/main"
+GOOS="linux" GOARCH="arm64" go build -ldflags='-s -w' -o linux/arm64/bin/main "$GOMOD/cmd/main"
 
 if [ "${STRIP:-false}" != "false" ]; then
-  strip bin/helper bin/main
+  strip linux/amd64/bin/helper linux/arm64/bin/helper
+  strip linux/amd64/bin/main linux/arm64/bin/main
 fi
 
-if [ "${COMPRESS:-false}" != "false" ]; then
-  upx -q -9 bin/helper bin/main
+if [ "${COMPRESS:-none}" != "none" ]; then
+  $COMPRESS linux/amd64/bin/helper linux/arm64/bin/helper
+  $COMPRESS linux/amd64/bin/main linux/arm64/bin/main
 fi
 
-ln -fs main bin/build
-ln -fs main bin/detect
+ln -fs main linux/amd64/bin/build
+ln -fs main linux/arm64/bin/build
+ln -fs main linux/amd64/bin/detect
+ln -fs main linux/arm64/bin/detect


### PR DESCRIPTION
## Summary

Add ARM64 support. There is nothing specific to ARM64 for this buildpack, but these changes will make the build scripts produce images with Go binaries compiled for each architecture.

Resolves https://github.com/paketo-buildpacks/dynatrace/issues/107 by removing `python` as an option and including the options that are available based on the documentation.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
