### PR TITLE
Fix Github 107

### DIFF
--- a/dt/build.go
+++ b/dt/build.go
@@ -57,11 +57,18 @@ func (b Build) Build(context libcnb.BuildContext) (libcnb.BuildResult, error) {
 
 	uri := fmt.Sprintf("%s/v1/deployment/installer/agent/unix/paas/latest?bitness=64&skipMetadata=true&arch=%s", BaseURI(s), archForDynatrace())
 
-	for _, t := range []string{"apache", "dotnet", "go", "java", "nginx", "nodejs", "php", "all", "sdk", "envoy"} {
-		if _, ok, err := pr.Resolve(fmt.Sprintf("dynatrace-%s", t)); err != nil {
-			return libcnb.BuildResult{}, fmt.Errorf("unable to resolve dynatrace-%s plan entry\n%w", t, err)
-		} else if ok {
-			uri = fmt.Sprintf("%s&include=%s", uri, t)
+	// not presently a specific python module, but we include "all" then it should work with Python
+	if _, ok, err := pr.Resolve("dynatrace-python"); err != nil {
+		return libcnb.BuildResult{}, fmt.Errorf("unable to resolve dynatrace-python plan entry\n%w", err)
+	} else if ok {
+		uri = fmt.Sprintf("%s&include=all", uri)
+	} else {
+		for _, t := range []string{"apache", "dotnet", "go", "java", "nginx", "nodejs", "php"} {
+			if _, ok, err := pr.Resolve(fmt.Sprintf("dynatrace-%s", t)); err != nil {
+				return libcnb.BuildResult{}, fmt.Errorf("unable to resolve dynatrace-%s plan entry\n%w", t, err)
+			} else if ok {
+				uri = fmt.Sprintf("%s&include=%s", uri, t)
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

A different fix for 107. It swaps Python for the `all` module that way the buildplan doesn't need to change.

## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
