### PR TITLE
Supports more specific plan combinations for PHP + web servers

### DIFF
--- a/dt/detect.go
+++ b/dt/detect.go
@@ -42,6 +42,26 @@ func (d Detect) Detect(context libcnb.DetectContext) (libcnb.DetectResult, error
 		Plans: []libcnb.BuildPlan{
 			{
 				Provides: []libcnb.BuildPlanProvide{
+					{Name: "dynatrace-php"},
+				},
+				Requires: []libcnb.BuildPlanRequire{
+					{Name: "dynatrace-php"},
+					{Name: "php"},
+					{Name: "httpd"},
+				},
+			},
+			{
+				Provides: []libcnb.BuildPlanProvide{
+					{Name: "dynatrace-php"},
+				},
+				Requires: []libcnb.BuildPlanRequire{
+					{Name: "dynatrace-php"},
+					{Name: "php"},
+					{Name: "nginx"},
+				},
+			},
+			{
+				Provides: []libcnb.BuildPlanProvide{
 					{Name: "dynatrace-apache"},
 				},
 				Requires: []libcnb.BuildPlanRequire{

--- a/dt/detect_test.go
+++ b/dt/detect_test.go
@@ -31,6 +31,26 @@ var expectedResult = libcnb.DetectResult{
 	Plans: []libcnb.BuildPlan{
 		{
 			Provides: []libcnb.BuildPlanProvide{
+					{Name: "dynatrace-php"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+					{Name: "dynatrace-php"},
+					{Name: "php"},
+					{Name: "httpd"},
+			},
+		},	
+		{
+			Provides: []libcnb.BuildPlanProvide{
+				{Name: "dynatrace-php"},
+			},
+			Requires: []libcnb.BuildPlanRequire{
+				{Name: "dynatrace-php"},
+				{Name: "php"},
+				{Name: "nginx"},
+			},
+		},
+		{
+			Provides: []libcnb.BuildPlanProvide{
 				{Name: "dynatrace-apache"},
 			},
 			Requires: []libcnb.BuildPlanRequire{


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
When used with the PHP buildpack and HTTPD as the webserver, the httpd/apache agent is installed instead of PHP.
To support this combination, as well as PHP + nginx, new plan entries for these combinations have been added.

## Use Cases
Tested Paketo PHP sample with both nginx and httpd as the server, both download the PHP agent
```
[builder] Paketo Buildpack for Dynatrace 11.0.0
[builder]   https://github.com/paketo-buildpacks/dynatrace
[builder]   Dynatrace OneAgent 1.291.121.20240531-083741: Contributing to layer
[builder]   Warning: Dependency has no SHA256. Skipping cache.
[builder]     Downloading from https://<url>.live.dynatrace.com/api/v1/deployment/installer/agent/unix/paas/latest?bitness=64&skipMetadata=true&arch=x86&include=php
[builder]     Expanding to /layers/paketo-buildpacks_dynatrace/dynatrace-oneagent
[builder]     Writing env.launch/BPI_DYNATRACE_BUILDPACK_ID.default
[builder]     Writing env.launch/BPI_DYNATRACE_BUILDPACK_VERSION.default
[builder]     Writing env.launch/DT_CUSTOM_PROP.append
[builder]     Writing env.launch/DT_CUSTOM_PROP.delim
[builder]     Writing env.launch/DT_LOGSTREAM.default
[builder]     Writing env.launch/LD_PRELOAD.delim
[builder]     Writing env.launch/LD_PRELOAD.prepend
[builder]   Launch Helper: Contributing to layer
[builder]     Creating /layers/paketo-buildpacks_dynatrace/helper/exec.d/properties`
```
## Checklist
<!-- Please confirm the following -->
* [ ] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [ ] I have added an integration test, if necessary.
* [ ] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [ ] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
